### PR TITLE
Refactor to reuse DataAccess helper

### DIFF
--- a/TPINT_GRUPO_4_PR3/Negocio/GestorMedico.cs
+++ b/TPINT_GRUPO_4_PR3/Negocio/GestorMedico.cs
@@ -20,17 +20,20 @@ namespace Negocio
         {
             return consultas.getMedicoPorID(idMedico);
         }
-        public int InsertarMedico(string nombreprocedimiento, Medico medico, Usuario usuario)
+        // Inserta un médico
+        public int InsertarMedico(Medico medico, Usuario usuario)
         {
-            return consultas.InsertarMedico(nombreprocedimiento, medico, usuario);
+            return consultas.InsertarMedico(medico, usuario);
         }
-        public int ModificarMedico(string nombreprocedimiento, Medico medico,Usuario usuario, string DNI_VIEJO, string LEGAJO_VIEJO)
+        // Modifica un médico existente
+        public int ModificarMedico(Medico medico,Usuario usuario, string DNI_VIEJO, string LEGAJO_VIEJO)
         {
-            return consultas.ModificarMedico(nombreprocedimiento, medico,usuario, DNI_VIEJO, LEGAJO_VIEJO);
+            return consultas.ModificarMedico(medico,usuario, DNI_VIEJO, LEGAJO_VIEJO);
         }
-        public int EliminarMedico(string nombreprocedimiento, string DNI)
+        // Elimina lógicamente un médico
+        public int EliminarMedico(string DNI)
         {
-            return consultas.EliminarMedico(nombreprocedimiento, DNI);
+            return consultas.EliminarMedico(DNI);
         }
     }
 }

--- a/TPINT_GRUPO_4_PR3/Negocio/GestorPaciente.cs
+++ b/TPINT_GRUPO_4_PR3/Negocio/GestorPaciente.cs
@@ -21,18 +21,21 @@ namespace Negocio
             return consultas.getPacientePorID(idPaciente);
         }
 
-        public int InsertarPaciente(string nombreprocedimiento, Paciente paciente)
+        // Inserta un paciente en la base de datos
+        public int InsertarPaciente(Paciente paciente)
         {
-            return consultas.InsertarPaciente(nombreprocedimiento, paciente);
+            return consultas.InsertarPaciente(paciente);
         }
 
-        public int ModificarPaciente(string nombreprocedimiento, Paciente paciente, string DNI_VIEJO)
+        // Modifica un paciente
+        public int ModificarPaciente(Paciente paciente, string DNI_VIEJO)
         {
-            return consultas.ModificarPaciente(nombreprocedimiento, paciente, DNI_VIEJO);
+            return consultas.ModificarPaciente(paciente, DNI_VIEJO);
         }
-        public int EliminarPaciente(string nombreprocedimiento, string DNI)
+        // Elimina lógicamente un paciente
+        public int EliminarPaciente(string DNI)
         {
-            return consultas.EliminarPaciente(nombreprocedimiento, DNI);
+            return consultas.EliminarPaciente(DNI);
         }
     }
 }

--- a/TPINT_GRUPO_4_PR3/Vistas/admin/Administrar_Medicos.aspx.cs
+++ b/TPINT_GRUPO_4_PR3/Vistas/admin/Administrar_Medicos.aspx.cs
@@ -41,7 +41,7 @@ namespace Vistas.admin
                     if (chk != null && chk.Checked)
                     {
                         string DNI = row.Cells[2].Text;
-                        gestorMedico.EliminarMedico("sp_EliminarMedico", DNI);
+                        gestorMedico.EliminarMedico(DNI);
                     }
                 }
                 loadGridMedicos();
@@ -135,8 +135,7 @@ namespace Vistas.admin
                 usuario.ultimoIngreso = Convert.ToDateTime(DateTime.Now);
                 usuario.idRol = 2;
 
-                string nombreProcedimiento = "sp_AltaMedico";
-                int filas = gestorMedico.InsertarMedico(nombreProcedimiento, medico, usuario);
+                int filas = gestorMedico.InsertarMedico(medico, usuario);
 
                 if (filas > 0)
                 {
@@ -180,8 +179,6 @@ namespace Vistas.admin
             string DNI_VIEJO = (Session["DNI_VIEJO"] as string).Trim();
             string LEGAJO_VIEJO = (Session["LEGAJO_VIEJO"] as string).Trim();
 
-            string nombreProcedimiento = "sp_ModificarMedico";
-
             //Validaciones anteriores a enviar los datos del Medico a modificar
 
             if (medico.DNI == "" || medico.Legajo == "" || medico.nombre == "" || medico.apellido == "")
@@ -202,7 +199,7 @@ namespace Vistas.admin
                 lblModificarMedico.Visible = true;
                 return;
             }
-            int filas = gestorMedico.ModificarMedico(nombreProcedimiento, medico, medico.Usuario, DNI_VIEJO, LEGAJO_VIEJO);
+            int filas = gestorMedico.ModificarMedico(medico, medico.Usuario, DNI_VIEJO, LEGAJO_VIEJO);
 
             if (filas > 0) // Verificación final luego de llamar al sp
             {

--- a/TPINT_GRUPO_4_PR3/Vistas/admin/Administrar_Pacientes.aspx.cs
+++ b/TPINT_GRUPO_4_PR3/Vistas/admin/Administrar_Pacientes.aspx.cs
@@ -33,7 +33,7 @@ namespace Vistas.admin
                     if (chk != null && chk.Checked)
                     {
                         string DNI = row.Cells[1].Text;
-                        gestorPaciente.EliminarPaciente("sp_EliminarPaciente", DNI);
+                        gestorPaciente.EliminarPaciente(DNI);
                     }
                 }
                 loadGridPacientes();
@@ -139,8 +139,7 @@ namespace Vistas.admin
             paciente.Telefono = txbTelefono.Text.Trim();
 
 
-            string nombreProcedimiento = "sp_AltaPaciente";
-            int filas = gestorPaciente.InsertarPaciente(nombreProcedimiento, paciente);
+            int filas = gestorPaciente.InsertarPaciente(paciente);
             if (filas > 0)
             {
                 lblAddUserState.Text = "Se agrego correctamente el Paciente";
@@ -175,8 +174,7 @@ namespace Vistas.admin
             paciente.Correo = txbModCorreo.Text.Trim();
 
             string DNI_VIEJO = (Session["DNI_VIEJO"] as string)?.Trim();
-            string nombreProcedimiento = "sp_ModificarPaciente";
-            int filas = gestorPaciente.ModificarPaciente(nombreProcedimiento, paciente, DNI_VIEJO);
+            int filas = gestorPaciente.ModificarPaciente(paciente, DNI_VIEJO);
             if (filas > 0)
             {
                 lblModUser.Text = "Se modifico correctamente el Paciente";


### PR DESCRIPTION
## Summary
- use `DataAccess.EjecutarComandoConParametros` for simple update queries
- keep inline transaction logic for complex operations

## Testing
- `dotnet build TPINT_GRUPO_4_PR3.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b05d15788325a3bc8e62619c3756